### PR TITLE
build: compile on modern macOS and Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc make libc6-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+COPY . .
+
+RUN cd src && make clean && make python
+
+WORKDIR /build/src
+CMD ["./python"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright 1991 by Stichting Mathematisch Centrum, Amsterdam, The Netherlands.
+
+                        All Rights Reserved
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the names of Stichting Mathematisch
+Centrum or CWI not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior permission.
+
+STICHTING MATHEMATISCH CENTRUM DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS, IN NO EVENT SHALL STICHTING MATHEMATISCH CENTRUM BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,6 +41,15 @@
 # you may have to toss out the tokenizer.o object.)
 
 
+# Modern Build Settings
+# =====================
+# Suppress warnings from 1991 K&R C on clang/gcc >= 10.
+# SIGTYPE=void matches what modern signal() expects.
+
+CC=	cc
+CFLAGS=	-std=gnu89 -w -Wno-incompatible-function-pointer-types -DSIGTYPE=void
+
+
 # Operating System Defines (ALWAYS READ THIS)
 # ===========================================
 
@@ -70,7 +79,7 @@ RANLIB =	ranlib	# For BSD
 # the interpreter from the source/build directory as distributed will
 # find the library (admittedly a hack).
 
-DEFPYTHONPATH= .:/usr/local/lib/python:/ufs/guido/lib/python:../lib
+DEFPYTHONPATH= .:/usr/local/lib/python:../lib
 
 
 # For "Pure" BSD Systems

--- a/src/bltinmodule.c
+++ b/src/bltinmodule.c
@@ -36,6 +36,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "compile.h" /* For ceval.h */
 #include "ceval.h"
 #include "modsupport.h"
+#include "fgetsintr.h"
 
 static object *
 builtin_abs(self, v)

--- a/src/ceval.h
+++ b/src/ceval.h
@@ -31,3 +31,5 @@ object *getglobals PROTO((void));
 object *getlocals PROTO((void));
 
 void printtraceback PROTO((FILE *));
+
+void flushline PROTO((void));


### PR DESCRIPTION
## What

Gets Python 0.9.1 (1991) building and running on modern systems with no changes to the interpreter logic.

Tested on:
- macOS 15 / Apple clang 17 (arm64)
- Debian bookworm / GCC 12 via podman

## Changes

**src/Makefile** — new section at the top:
- `CC = cc`, `CFLAGS = -std=gnu89 -w -Wno-incompatible-function-pointer-types -DSIGTYPE=void`
- `-std=gnu89` keeps K&R implicit-int and implicit-function-decl as warnings rather than hard errors; `-w` silences them
- Clang 16+ promotes `-Wincompatible-function-pointer-types` to a hard error by default (`free` used as `void (*)(object *)` dealloc slot); the explicit flag turns it back off
- `DEFPYTHONPATH` cleaned up to drop the old SGI `/ufs/guido/...` path

**src/ceval.h** — add declaration for `flushline()`. It is defined in `ceval.c` but bltinmodule.c calls it with no visible declaration, which is a hard error in C99+.

**src/bltinmodule.c** — add `#include "fgetsintr.h"` so `fgets_intr()` is declared before use. Same class of bug.

**Dockerfile** — Debian bookworm-slim, installs `gcc make libc6-dev`, runs `make clean && make python` to build the Linux binary from scratch inside the container.

## Quick start

macOS:
```sh
cd src && make python
printf "x = 'hello'\nprint x\n" | ./python
```

Linux (podman):
```sh
podman build -t python091 .
printf "x = 'hello'\nprint x\n" | podman run --rm -i python091 ./python
```

Note: Python 0.9.1 uses single-quoted strings only. Double quotes are not part of the language yet.